### PR TITLE
Correction of HBASE_VERSION in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Apache HBase Dockerfiles for a Single Node Cluster
 
 ## build
 ```
-$ docker build --build-arg HBASE_VERSION="2.1.4" \
+$ docker build --build-arg HBASE_VERSION="2.1.5" \
 -t kirasoa/apache-hbase-standalone:2.1.4 \
 -t kirasoa/apache-hbase-standalone:latest \
 -f Dockerfile.standalone .


### PR DESCRIPTION
It should be 2.1.5. See http://ftp.jaist.ac.jp/pub/apache/hbase/